### PR TITLE
Restore Ctrl + h as left pane navigation

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -33,6 +33,8 @@ Plug 'tpope/vim-fugitive/'
 
 " Add PHP.net docs with SHIFT+k overkeyword key binding.
 Plug 'alvan/vim-php-manual'
+" Prevent mapping Ctrl+h to open the manual page in PHP.net
+let g:php_manual_online_search_shortcut = ''
 
 " Add WordPress dictionary and syntax to PHP files
 Plug 'salcode/vim-wordpress-dict'


### PR DESCRIPTION
Prevent the PHP Manual Vim Plugin from creating a mapping for Ctrl + h
(opening the word under the cursor in php.net).

We avoid this mapping, so Ctrl + h can be used as pane navigation to the left.

See #151