### PR TITLE
Add :JSONFormat to pretty print format JSON

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -361,6 +361,9 @@ command! -bang BD call BufDeleteKeepSplit(<bang>0)
 " :BufOnly closes all buffers except the current one
 command! BufOnly execute '%bdelete|edit #|normal `"'
 
+" :JSONFormat custom command to format for a given range (or current line).
+command! -range JSONFormat <line1>,<line2>!python -m json.tool
+
 " Close buffer while keeping the split open.
 " @param bang Is a 0 or 1 indicating if the command ended with a bang (!).
 "     i.e. close the buffer even if it is modified.


### PR DESCRIPTION
The `:JSONFormat` command can be used with or without a range. When no
range is given the current line is formatted.

See blog post [Vim JSON format](https://salferrarello.com/vim-json-format/) for more information.

Fixes #181