### PR TITLE
Set Neovim option inccommand=nosplit

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -149,6 +149,11 @@ set ignorecase
 " override ignorecase if the search pattern contains upper case characters
 set smartcase
 
+" Preview effects of command incrementally (e.g. :substitute). Neovim only.
+if has('nvim')
+	set inccommand=nosplit
+endif
+
 " add `-` as part of the word in all situations
 set iskeyword+=-
 


### PR DESCRIPTION
Since this is a Neovim only option, we wrap it in a conditional to check
we are in Neovim

Fixes #143