### PR TITLE
Add normal mode 'S' mapping for split line

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -513,3 +513,7 @@ endf
 " Attempt to load a project specific vdebug path map file from the
 " current directory.
 exe "call FeLocalVDebugPathMaps('.vdebug_path_maps')"
+
+" Add normal command 'S' to intelligently split a line.
+" See https://github.com/drzel/vim-split-line
+nnoremap S :keeppatterns substitute/\s*\%#\s*/\r/e <bar> normal! ==<CR>


### PR DESCRIPTION
Add normal mode 'S' mapping for intelligent split line

- Splits the line under the cursor
- Remove trailing whitespace on first line
- Auto-indents second line

See https://github.com/drzel/vim-split-line

Fixes #180