### PR TITLE
Set absolute line number when in insert mode

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -124,6 +124,12 @@ set list
 " show absolute line number on current line, relative line number on all others
 set number relativenumber
 
+augroup fe_absolute_line_number_toggle
+  autocmd!
+  autocmd BufEnter,FocusGained,InsertLeave * set relativenumber
+  autocmd BufLeave,FocusLost,InsertEnter   * set norelativenumber
+augroup END
+
 " display tabs as taking up 4 spaces
 set tabstop=4
 


### PR DESCRIPTION
We already use hybrid lines numbers:

- absolute for the current line
- relative for all other lines

Additionally, it would be nice to switch to all absolute line numbers
when in insert mode - this change does this.

See https://jeffkreeftmeijer.com/vim-number/

Fixes #171