### PR TITLE
Add mappings for staging Git hunks

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -579,6 +579,11 @@ function! GitHunkToggle()
 	endif
 endfunction
 
+augroup fe_git_commit_hunk
+	autocmd!
+	autocmd FileType diff nnoremap <buffer> <leader><leader> :call GitHunkToggle()<CR>
+augroup END
+
 function! IsFirstCharacter(characterToCompare) abort
 	let l:rowContent           = getline('.')
 	let l:colPos               = col('.')

--- a/init.vim
+++ b/init.vim
@@ -524,6 +524,9 @@ exe "call FeLocalVDebugPathMaps('.vdebug_path_maps')"
 " See https://github.com/drzel/vim-split-line
 nnoremap S :keeppatterns substitute/\s*\%#\s*/\r/e <bar> normal! ==<CR>
 
+" --------------------------------------
+" --  Begin Git staging Hunks Helpers --
+" --------------------------------------
 function! UnAddLine()
 	" Store current position
 	let position = winsaveview()
@@ -593,3 +596,6 @@ function! IsFirstCharacter(characterToCompare) abort
 		return 1
 	endif
 endfunction
+" --------------------------------------
+" --- End Git staging Hunks Helpers ----
+" --------------------------------------

--- a/init.vim
+++ b/init.vim
@@ -538,3 +538,18 @@ function! UnAddLine()
 	" Delete current line
 	execute ":normal dd"
 endfunction
+
+function! UnDeleteLine()
+	" Store current position
+	let position = winsaveview()
+	" Jump to second line
+	execute ":2"
+	" Move to the last number.
+	execute ":normal 2t@h"
+	" Increment the value under the cursor.
+	execute ':normal ' . "\<C-A>"
+	" Restore position
+	call winrestview(position)
+	" Remove the leading - sign
+	execute "normal 0r "
+endfunction

--- a/init.vim
+++ b/init.vim
@@ -569,6 +569,16 @@ function! DeleteLine()
 	execute "normal 0r-"
 endfunction
 
+function! GitHunkToggle()
+	if IsFirstCharacter('-')
+		call UnDeleteLine()
+	elseif IsFirstCharacter('+')
+		call UnAddLine()
+	elseif IsFirstCharacter(' ')
+		call DeleteLine()
+	endif
+endfunction
+
 function! IsFirstCharacter(characterToCompare) abort
 	let l:rowContent           = getline('.')
 	let l:colPos               = col('.')

--- a/init.vim
+++ b/init.vim
@@ -568,3 +568,13 @@ function! DeleteLine()
 	" Add a leading - sign
 	execute "normal 0r-"
 endfunction
+
+function! IsFirstCharacter(characterToCompare) abort
+	let l:rowContent           = getline('.')
+	let l:colPos               = col('.')
+	let l:firstCharacter = strpart( l:rowContent, 0, 1)
+	" echo l:firstCharacter
+	if l:firstCharacter ==# a:characterToCompare
+		return 1
+	endif
+endfunction

--- a/init.vim
+++ b/init.vim
@@ -553,3 +553,18 @@ function! UnDeleteLine()
 	" Remove the leading - sign
 	execute "normal 0r "
 endfunction
+
+function! DeleteLine()
+	" Store current position
+	let position = winsaveview()
+	" Jump to second line
+	execute ":2"
+	" Move to the last number.
+	execute ":normal 2t@h"
+	" Decrement the value under the cursor.
+	execute ':normal ' . "\<C-X>"
+	" Restore position
+	call winrestview(position)
+	" Add a leading - sign
+	execute "normal 0r-"
+endfunction

--- a/init.vim
+++ b/init.vim
@@ -523,3 +523,18 @@ exe "call FeLocalVDebugPathMaps('.vdebug_path_maps')"
 " Add normal command 'S' to intelligently split a line.
 " See https://github.com/drzel/vim-split-line
 nnoremap S :keeppatterns substitute/\s*\%#\s*/\r/e <bar> normal! ==<CR>
+
+function! UnAddLine()
+	" Store current position
+	let position = winsaveview()
+	" Jump to second line
+	execute ":2"
+	" Move to the last number.
+	execute ":normal 2t@h"
+	" Decrement the value under the cursor.
+	execute ':normal ' . "\<C-X>"
+	" Restore position
+	call winrestview(position)
+	" Delete current line
+	execute ":normal dd"
+endfunction


### PR DESCRIPTION
When in a `gitdiff` filetype (i.e. when editing a Git hunk to stage), hitting `<leader><leader>` (in our case `<space><space>`) it will toggle the state of the line between:

- add (`+`)
- delete (`-`)
- or no change (` `)

See #185