### PR TITLE
Use vim-airline jsformatter for JavaScript files

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -6,3 +6,6 @@ setlocal noexpandtab
 
 " Treat `$` as part of the word
 setlocal iskeyword+=$
+
+" Include directory name in tabline for JS files named index.js
+let g:airline#extensions#tabline#formatter = 'jsformatter'


### PR DESCRIPTION
This addresses the problem where JavaScript files are often named
index.js. Since we are displaying file names in the tabline, all buffers
will be labeled index.js (which isn't helpful).

Using jsformatter the directory is displayed in the tab name.

Fixes #203