### PR TITLE
Add :Rg search command to use ripgrep search

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -533,6 +533,19 @@ function! FeAg(func)
 endf
 command! -nargs=* Ag :silent call FeAg("<args>")
 
+" Add :Rg command, which behaves like :grep but uses
+" the rg command instead of grep
+function! FeRg(func)
+  let tmp1=&grepprg
+  let tmp2=&grepformat
+  set grepprg=rg\ --vimgrep\ --type-not\ sql\ --smart-case\ $*
+  set grepformat=%f:%l:%c:%m
+  exe "grep ".a:func
+  exe "set grepprg=".escape(tmp1,' ')
+  exe "set grepformat=".escape(tmp2, ' ')
+endf
+command! -nargs=* Rg :silent call FeRg("<args>")
+
 " Set vdebug_options.
 " Note: the path_maps will need to be updated when changing between projects.
 let g:vdebug_options= {


### PR DESCRIPTION
Add `:Rg` command that uses ripgrep when performing a search (like the native
`:grep` command does)

Fixes #207

See #95, #165