### PR TITLE
Add syntax highlighting for merge conflict markers

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -107,6 +107,10 @@ syntax enable
 
 " Perform syntax highlighting for the first 256 columns only.
 set synmaxcol=256
+
+" Highlight merge conflict markers
+match Error '\v^(\<|\=|\>){7}([^=].+)?$'
+
 " }}} Syntax highlighting.
 
 " {{{ Invisible characters.


### PR DESCRIPTION
Note: We are using 'Error' as the syntax group name
(see :help group-name) rather than some of the other choices we
evaluated (e.g. 'Todo' and 'ErrorMsg') because the rendering is
preferable with our colorscheme of choice (sjl/badwolf)

See https://github.com/salcode/ironcode-vim/issues/154#issuecomment-860192112

See #154

## Before PR

![image](https://user-images.githubusercontent.com/5194588/121804542-e1860100-cc14-11eb-90bf-4daa0e1ae904.png)

## After PR

![image](https://user-images.githubusercontent.com/5194588/121804530-d337e500-cc14-11eb-97a5-1be90193bc6c.png)